### PR TITLE
Fix issue with subnet_ids list variable being put into a list in the aws_db_subnet_group resource and issue with records in dns_host_name module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -109,5 +109,5 @@ module "dns_host_name" {
   name      = "${var.host_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.dns_zone_id}"
-  records   = ["${aws_db_instance.default.*.address}"]
+  records   = coalescelist(aws_db_instance.default.*.address, [""])
 }

--- a/main.tf
+++ b/main.tf
@@ -109,5 +109,5 @@ module "dns_host_name" {
   name      = "${var.host_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.dns_zone_id}"
-  records   = coalescelist(aws_db_instance.default[*].address, [""])
+  records   = aws_db_instance.default.*.address
 }

--- a/main.tf
+++ b/main.tf
@@ -103,7 +103,7 @@ resource "aws_security_group_rule" "allow_egress" {
 }
 
 module "dns_host_name" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.2.5"
+  source    = "git::https://github.com/cloudposse/terraform-aws-route53-cluster-hostname.git?ref=tags/0.9.0"
   enabled   = "${local.enabled && length(var.dns_zone_id) > 0 ? "true" : "false"}"
   namespace = "${var.namespace}"
   name      = "${var.host_name}"

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ resource "aws_db_instance" "default" {
 resource "aws_db_subnet_group" "default" {
   count      = "${local.enabled && var.same_region == "false" ? 1 : 0}"
   name       = "${module.label.id}"
-  subnet_ids = ["${var.subnet_ids}"]
+  subnet_ids = "${var.subnet_ids}"
   tags       = "${module.label.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -109,5 +109,5 @@ module "dns_host_name" {
   name      = "${var.host_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.dns_zone_id}"
-  records   = coalescelist(aws_db_instance.default.*.address, [""])
+  records   = coalescelist(aws_db_instance.default[*].address, [""])
 }

--- a/main.tf
+++ b/main.tf
@@ -109,5 +109,5 @@ module "dns_host_name" {
   name      = "${var.host_name}"
   stage     = "${var.stage}"
   zone_id   = "${var.dns_zone_id}"
-  records   = "${aws_db_instance.default.*.address}"
+  records   = ["${aws_db_instance.default.*.address}"]
 }


### PR DESCRIPTION
Closes #11 

Currently, the subnet_ids variable is defined as a list in the variables.tf. This variable is then getting set to a list which is causing the aws_db_subnet_group to fail to create because the subnet_ids are being passed as a list of lists, not a list of strings. This PR should resolve this issue and close issue #11 

Also upgrading the version on the dns_host_name module to fix an issue with that resource