### PR TITLE
Missing ending " in README example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ module "rds_replica" {
   namespace                   = "eg"
   stage                       = "prod"
   name                        = "reporting"
-  replicate_source_db         = "eg-prod-db
+  replicate_source_db         = "eg-prod-db"
   dns_zone_id                 = "Z89FN1IW975KPE"
   host_name                   = "reporting"
   security_group_ids          = ["sg-xxxxxxxx"]


### PR DESCRIPTION
## what

- Added a missing quote in README usage code example
<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

- It was missing.
<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
